### PR TITLE
UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Embeds a clickable youtube thumbnail instead of the iframe. Upon clicking, loads
 <Youtube id="q2Y3f0lHnMs">
   <button>play</button>
 </Youtube>
+
+<!-- Custom overlay -->
+<Youtube id="q2Y3f0lHnMs" --overlay-bg-color="hsla(0, 0%, 0%, 0.3)" --overlay-transition="all 100ms linear" />
+
 ```
 
 The `id` is youtube video id. In this video link `https://www.youtube.com/watch?v=q2Y3f0lHnMs`, the id is `q2Y3f0lHnMs`.

--- a/src/lib/Youtube.svelte
+++ b/src/lib/Youtube.svelte
@@ -20,6 +20,7 @@
       alt="Youtube video"
       referrerpolicy="no-referrer"
     />
+    <div class="overlay" on:click={() => (play = true)} />
     <Button on:click={() => (play = true)} {isCustomPlayButton}>
       <slot />
     </Button>
@@ -36,5 +37,17 @@
     height: auto;
     aspect-ratio: 16/9;
     width: 100%;
+  }
+  .overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    aspect-ratio: 16/9;
+    cursor: pointer;
+    transition: var(--overlay-transition, all 250ms ease-in-out);
+  }
+  .yt:hover .overlay {
+    background: var(--overlay-bg-color, rgba(0, 0, 0, 0.1));
   }
 </style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -20,6 +20,10 @@
     <button>play</button>
   </Youtube>
 
+  <h2>Using custom overlay</h2>
+
+  <Youtube id="q2Y3f0lHnMs" --overlay-bg-color="rgba(184, 75, 132, 0.3)" --overlay-transition="all 100ms linear" />
+
   <ul>
     <li>
       <a href="https://github.com/sharu725/youtube-embed">Github</a>


### PR DESCRIPTION
Using overlay that plays the video on click, thus easier for users to play videos on touch devices.
Allowing developers to specify the overlay color and transition
Updated `README` with an example of this update
Updated `index.svelte` with a live example