### PR TITLE
UI, UX & DX enhancements, workaround for default low quality thumbnails and more ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Embeds a clickable youtube thumbnail instead of the iframe. Upon clicking, loads
 <!-- Custom overlay -->
 <Youtube id="q2Y3f0lHnMs" --overlay-bg-color="hsla(0, 0%, 0%, 0.3)" --overlay-transition="all 100ms linear" />
 
+<!-- Custom title -->
+<Youtube id="kgZeIDSHlhQ" --title-color="#111111" --title-shadow-color="#cccccc" --title-font-family="Lato, sans-serif" />
+
+<!-- Alternative thumbnail -->
+<Youtube id="g50dm1OCV3w" alternativeThumbnail={true} />
 ```
 
 The `id` is youtube video id. In this video link `https://www.youtube.com/watch?v=q2Y3f0lHnMs`, the id is `q2Y3f0lHnMs`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Embeds a clickable youtube thumbnail instead of the iframe. Upon clicking, loads
 <!-- Custom title -->
 <Youtube id="kgZeIDSHlhQ" --title-color="#111111" --title-shadow-color="#cccccc" --title-font-family="Lato, sans-serif" />
 
-<!-- Alternative thumbnail -->
+<!-- Alternative thumbnail if default thumbnail doesn't show automatically -->
 <Youtube id="g50dm1OCV3w" alternativeThumbnail={true} />
 ```
 

--- a/src/lib/Youtube.svelte
+++ b/src/lib/Youtube.svelte
@@ -27,7 +27,9 @@
       />
     {:else}
       <img
-        src="https://i.ytimg.com/vi/{id}/{alternativeThumbnail ? 'hqdefault' : 'maxresdefault'}.jpg"
+        src="https://i.ytimg.com/vi/{id}/{alternativeThumbnail
+          ? 'hqdefault'
+          : 'maxresdefault'}.jpg"
         title={jsonObj.title}
         alt="Youtube video: {jsonObj.title}"
         referrerpolicy="no-referrer"
@@ -60,7 +62,13 @@
     pointer-events: none;
   }
   .video-title h3 {
-    font-family: "Segoe UI", Geneva, Verdana, sans-serif;
+    font-family: var(
+      --title-font-family,
+      "Segoe UI",
+      Geneva,
+      Verdana,
+      sans-serif
+    );
     color: var(--title-color, #ffffff);
     padding: 0 2ch;
     font-weight: 400;

--- a/src/lib/Youtube.svelte
+++ b/src/lib/Youtube.svelte
@@ -1,31 +1,45 @@
 <script>
   import Button from "./Button.svelte";
   export let id = null;
+  export let alternativeThumbnail = false;
+
+  let videoInfo = fetch(
+    `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${id}&format=json`
+  ).then((res) => res.json());
+
   let play = false;
   const isCustomPlayButton = $$slots.default;
 </script>
 
-<div class="yt">
-  {#if play}
-    <iframe
-      src="https://www.youtube.com/embed/{id}?autoplay=1&rel=0"
-      title="YouTube video player"
-      frameborder="0"
-      allow="autoplay; picture-in-picture; clipboard-write"
-      allowfullscreen
-    />
-  {:else}
-    <img
-      src="https://i.ytimg.com/vi/{id}/maxresdefault.jpg"
-      alt="Youtube video"
-      referrerpolicy="no-referrer"
-    />
-    <div class="overlay" on:click={() => (play = true)} />
-    <Button on:click={() => (play = true)} {isCustomPlayButton}>
-      <slot />
-    </Button>
-  {/if}
-</div>
+{#await videoInfo then jsonObj}
+  <div
+    class="yt"
+    style="--aspect-ratio:{jsonObj.width / jsonObj.height || '16/9'}"
+    title={jsonObj.title}
+  >
+    {#if play}
+      <iframe
+        src="https://www.youtube.com/embed/{id}?autoplay=1&rel=0"
+        title={jsonObj.title}
+        frameborder="0"
+        allow="autoplay; picture-in-picture; clipboard-write"
+        allowfullscreen
+      />
+    {:else}
+      <img
+        src="https://i.ytimg.com/vi/{id}/{alternativeThumbnail ? 'hqdefault' : 'maxresdefault'}.jpg"
+        title={jsonObj.title}
+        alt="Youtube video: {jsonObj.title}"
+        referrerpolicy="no-referrer"
+      />
+      <div class="overlay" on:click={() => (play = true)} />
+      <div class="video-title"><h3>{jsonObj.title}</h3></div>
+      <Button on:click={() => (play = true)} {isCustomPlayButton}>
+        <slot />
+      </Button>
+    {/if}
+  </div>
+{/await}
 
 <style>
   .yt {
@@ -35,19 +49,33 @@
   img,
   iframe {
     height: auto;
-    aspect-ratio: 16/9;
+    aspect-ratio: var(--aspect-ratio);
     width: 100%;
+  }
+  .video-title {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    background: linear-gradient(to bottom, hsla(0, 0%, 0%, 0.1), transparent);
+    pointer-events: none;
+  }
+  .video-title h3 {
+    font-family: "Segoe UI", Geneva, Verdana, sans-serif;
+    color: var(--title-color, #ffffff);
+    padding: 0 2ch;
+    font-weight: 400;
+    text-shadow: 0px 1px 3px var(--title-shadow-color, rgb(0, 0, 0, 0.2));
   }
   .overlay {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
-    aspect-ratio: 16/9;
+    aspect-ratio: var(--aspect-ratio);
     cursor: pointer;
     transition: var(--overlay-transition, all 250ms ease-in-out);
   }
   .yt:hover .overlay {
-    background: var(--overlay-bg-color, rgba(0, 0, 0, 0.1));
+    background: var(--overlay-bg-color, #00000030);
   }
 </style>

--- a/src/lib/Youtube.svelte
+++ b/src/lib/Youtube.svelte
@@ -11,7 +11,7 @@
       src="https://www.youtube.com/embed/{id}?autoplay=1&rel=0"
       title="YouTube video player"
       frameborder="0"
-      allow="autoplay"
+      allow="autoplay; picture-in-picture; clipboard-write"
       allowfullscreen
     />
   {:else}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,5 +1,12 @@
 <script>
   import Youtube from "$lib/Youtube.svelte";
+  let overlayBGColor = "#e5a50a";
+  let overlayTransitionDuration = 50;
+
+  let titleColor = "#000000";
+  let titleShadowColor = "#ffffff";
+
+  let alternativeThumbnail = false;
 </script>
 
 <div class="container">
@@ -21,8 +28,59 @@
   </Youtube>
 
   <h2>Using custom overlay</h2>
+  <div class="controls">
+    <label for="overlay-color-select">Overlay color</label>
+    <input id="overlay-color-select" type="color" bind:value={overlayBGColor} />
+    <label for="overlay-transition-duration">Overlay transition duration</label>
+    <input
+      id="overlay-transition-duration"
+      min="0"
+      max="1000"
+      type="range"
+      step="50"
+      bind:value={overlayTransitionDuration}
+    />
+  </div>
+  <pre>&lt;Youtube id="q2Y3f0lHnMs" --overlay-bg-color="{overlayBGColor}30" --overlay-transition="all {overlayTransitionDuration}ms linear" /&gt;</pre>
 
-  <Youtube id="q2Y3f0lHnMs" --overlay-bg-color="rgba(184, 75, 132, 0.3)" --overlay-transition="all 100ms linear" />
+  <Youtube
+    id="q2Y3f0lHnMs"
+    --overlay-bg-color="{overlayBGColor}30"
+    --overlay-transition="all {overlayTransitionDuration}ms linear"
+  />
+
+  <h2>Using custom title colors</h2>
+  <div class="controls">
+    <label for="title-color-select">Title color</label>
+    <input id="title-color-select" type="color" bind:value={titleColor} />
+    <label for="title-shadow-color">Title shadow color</label>
+    <input id="title-shadow-color" type="color" bind:value={titleShadowColor} />
+  </div>
+  <pre>&lt;Youtube id="kgZeIDSHlhQ" --title-color={titleColor} --title-shadow-color={titleShadowColor}30 /&gt;</pre>
+
+  <Youtube
+    id="kgZeIDSHlhQ"
+    --title-color={titleColor}
+    --title-shadow-color="{titleShadowColor}30"
+  />
+
+  <h2>Alternative thumbnail</h2>
+  <sub>
+    Some videos don't have custom thumbnail, so you can use this option to set
+    the thumbnail to the default one.
+  </sub>
+  <div class="controls">
+    <label for="alt-thumbnail-checkbox">Toggle</label>
+    <input
+      id="alt-thumbnail-checkbox"
+      type="checkbox"
+      bind:checked={alternativeThumbnail}
+    />
+  </div>
+
+  <pre>&lt;Youtube id="g50dm1OCV3w" alternativeThumbnail=&lbrace;{alternativeThumbnail}&rbrace; /&gt;</pre>
+
+  <Youtube id="g50dm1OCV3w" {alternativeThumbnail} />
 
   <ul>
     <li>
@@ -48,5 +106,19 @@
   }
   li {
     margin-right: 1rem;
+  }
+  .controls {
+    display: flex;
+    align-items: center;
+    margin: 1rem auto;
+  }
+  .controls label {
+    margin-left: 1em;
+  }
+  pre {
+    padding: 0.5em 1em;
+    background-color: #e9e9e9;
+    border: 1px solid rgb(180, 180, 180);
+    border-radius: 3px;
   }
 </style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -5,6 +5,7 @@
 
   let titleColor = "#000000";
   let titleShadowColor = "#ffffff";
+  let titleFontFamily = "'Segoe UI', Geneva, Verdana, sans-serif";
 
   let alternativeThumbnail = false;
 </script>
@@ -55,13 +56,28 @@
     <input id="title-color-select" type="color" bind:value={titleColor} />
     <label for="title-shadow-color">Title shadow color</label>
     <input id="title-shadow-color" type="color" bind:value={titleShadowColor} />
+    <label for="title-font-family">Font family</label>
+    <select
+      name="title-font-family"
+      id="title-font-family"
+      bind:value={titleFontFamily}
+    >
+      <option value="'Roboto', sans-serif">Roboto</option>
+      <option value="'Segoe UI', Geneva, Verdana, sans-serif">Segoe UI</option>
+      <option value="'Helvetica Neue', Helvetica, Arial, sans-serif"
+        >Helvetica Neue</option
+      >
+      <option value="'Times New Roman', Times, serif">Times New Roman</option>
+      <option value="'Courier New', Courier, monospace">Courier New</option>
+    </select>
   </div>
-  <pre>&lt;Youtube id="kgZeIDSHlhQ" --title-color={titleColor} --title-shadow-color={titleShadowColor}30 /&gt;</pre>
+  <pre>&lt;Youtube id="kgZeIDSHlhQ" --title-color="{titleColor}" --title-shadow-color="{titleShadowColor}30" --title-font-family="{titleFontFamily}" /&gt;</pre>
 
   <Youtube
     id="kgZeIDSHlhQ"
     --title-color={titleColor}
     --title-shadow-color="{titleShadowColor}30"
+    --title-font-family={titleFontFamily}
   />
 
   <h2>Alternative thumbnail</h2>
@@ -120,5 +136,6 @@
     background-color: #e9e9e9;
     border: 1px solid rgb(180, 180, 180);
     border-radius: 3px;
+    white-space: pre-wrap;
   }
 </style>


### PR DESCRIPTION
## Video info
The component now fetches video information from youtube asynchronously using svelte sugar `await .. then` syntax.
I used two pieces of information from that response which are:
- Video width & height
- Video title

### Video width and height
I'm using those to calculate aspect ratio (for max compatibility) to be used for the image & overlay, I also set a default fallback to `16 / 9` in case the request fails.

### Video title
It is now used in multiple places, in top of the interface, a bit similar to youtube embedded iFrame.

It's also used for the HTML attribute `title` for some elements, I also think it should enhance accessibility.

### Default thumbnails
Some videos don't have a custom thumbnail, so YouTube normally would pick a frame from the video and assign it with the name `hqdefault.jpg`.

In this update, I added a prop called `alternativeThumbnail` to `Youtube.svelte` with the default value of `false`, normally, the component requests `maxresdefault.jpg`, but if this prop was set to `true` , it will request `hqdefault.jpg`.

### Feature policy
I added [Picture in Picture](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/picture-in-picture) permission for the iframe as well as `clipboard-write` to allow copying video url.

## Demo
I updated `index.svelte` and added two new demos.

### Title controls
- Devs can send style props to control title color, background color and font family.
- Devs can preview overlay color and transition duration.
- Devs can now choose alternativeThumbnail.