### PR TITLE
adds a comment disabling svelte a11y checks for the overlay

### DIFF
--- a/src/lib/Youtube.svelte
+++ b/src/lib/Youtube.svelte
@@ -41,6 +41,7 @@
     {:else}
       <Image {id} {title} {altThumb} {play} />
     {/if}
+    <!-- svelte-ignore a11y-no-static-element-interactions (because no a11y roles map to a clickable overlay) -->
     <div class="b__overlay" on:click={() => (play = true)} on:keypress={() => (play = true)} />
     <div class="v__title"><h3>{title}</h3></div>
   {/if}


### PR DESCRIPTION
This closes #30. I read through https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles and didn't find a role that cleanly maps to an overlay. There's a dialog role: 

> window that separates content or UI from the rest of the web application or page

But the overlay is just a background and doesn't really have it's own content for screen readers

Instead of giving it an aria-role that doesn't match. I'd rather suppress the warning