### PR TITLE
Add `homepage` and `repo` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "prepublishOnly": "npm run package",
     "vercel": "vite build"
   },
+  "homepage": "https://embed.sveltethemes.dev/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sharu725/youtube-embed.git"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Add the `homepage` and `repository` fields to the `package.json` file so that they can be seen on https://www.npmjs.com/package/svelte-youtube-embed

I was looking at this library on NPM and I wanted to find the GitHub repo/source-code since it had no `license`!

See: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#homepage
See: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository

### Examples

E.g. this is what https://www.npmjs.com/package/svelte-youtube-embed currently looks like:

![image](https://github.com/user-attachments/assets/158c50eb-c2b1-4632-97d7-e334b7fd34a0)

After this change and the next release, a **Repository** and **Homepage** field should be added as well:

![image](https://github.com/user-attachments/assets/2ca0eee8-3cfd-4002-847c-dd1d7f3f1bab)
