### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-2025 Webjeda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "svelte-youtube-embed",
   "version": "0.4.2",
+  "license": "MIT",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",


### PR DESCRIPTION
This PR adds an MIT license to this package.

@sharu725, I used `Copyright (c) 2022-2025 Webjeda` since that's what I saw in https://github.com/sharu725/yuyutsu/blob/6bfd0a516e0d8c849cb4cf760a7eff4771395b6d/LICENSE.md?plain=1#L1, but feel free to replace it with your GitHub username/real name instead!

And I'm going to CC-in the following other contributors, just to check if they're okay with adding the MIT license too (I think their contributions might be small enough to not count as copyrightable, but it's worth letting them know!):

CC-ing @amr3k, @kohbanye, @svelterust, @willgottschalk.

Fixes: https://github.com/sharu725/youtube-embed/issues/36